### PR TITLE
Perform final update in a shutdown hook

### DIFF
--- a/src/main/scala/FlowTracker.scala
+++ b/src/main/scala/FlowTracker.scala
@@ -284,14 +284,11 @@ class FlowTracker(val flow: Flow[_], val runCompleted: AtomicBoolean, val hostPo
     val tracker = FlowTracker.this
 
     override def run(): Unit = {
-      LOG.info("Entering shutdown hook")
-      if (!tracker.runCompleted.get) {
+      if (!tracker.runCompleted.get && tracker.client != null) {
         LOG.info("Performing final update from shutdown hook")
         tracker.updateSteps
         tracker.updateFlow
-        if (tracker.client != null) {
-          tracker.client.getHttpConnectionManager.asInstanceOf[MultiThreadedHttpConnectionManager].shutdown
-        }
+        tracker.client.getHttpConnectionManager.asInstanceOf[MultiThreadedHttpConnectionManager].shutdown
       }
     }
   }

--- a/src/main/scala/FlowTracker.scala
+++ b/src/main/scala/FlowTracker.scala
@@ -1,8 +1,5 @@
 package com.etsy.sahale
 
-import cascading.util.ShutdownUtil
-import cascading.util.ShutdownUtil.Hook
-import cascading.util.ShutdownUtil.Hook.Priority
 import org.apache.commons.httpclient.{HttpClient, MultiThreadedHttpConnectionManager, Header}
 import org.apache.commons.httpclient.cookie.CookiePolicy
 import org.apache.commons.httpclient.methods.PostMethod


### PR DESCRIPTION
This handles an edge case in tracking where the client JVM is killed with a SIGTERM.  This can prevent sending a final update, but doing a final update in a shutdown hook will make it more likely for this to go through.
