### PR TITLE
Update step configuration more often

### DIFF
--- a/src/main/scala/FlowTracker.scala
+++ b/src/main/scala/FlowTracker.scala
@@ -147,12 +147,14 @@ class FlowTracker(val flow: Flow[_], val runCompleted: AtomicBoolean, val hostPo
     flow.getFlowSteps.toList.foldLeft(Map.empty[String, StepStatus]) {
       (next: Map[String, StepStatus], fs: FlowStep[_]) =>
         val hfs: HadoopFlowStep = fs.asInstanceOf[HadoopFlowStep]
+        val conf = hfs.getConfig
         val id = hfs.getID
         val oldStatus = stepStatusMap(id).stepStatus
         val newStatus = hfs.getFlowStepStats.getStatus.toString
         (oldStatus, newStatus) match {
           case (o, n) if (n == "RUNNING" || o != n) => {
             stepStatusMap(id).update(hfs)
+            stepStatusMap(id).setConfigurationProperties(conf)
             next ++ Map(id -> stepStatusMap(id))
           }
           case _  => next


### PR DESCRIPTION
I believe there's a race condition between when the `onStarting` method of a FlowListener runs and when  FlowGraphBuilder executes.  If a job has a FlowListener attached that sets configuration properties on some stage of a job, they are not always picked up and pushed to Sahale when FlowGraphBuilder calls `setConfigurationProperties` on StepStatus. 

With this change we'll update the values of the step configuration properties when the rest of the step information is updated, which should avoid the issue entirely.
