### PR TITLE
Switch to the new scala-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,9 +69,9 @@
       <plugins>
         <!-- Raise the default heap and thread stack sizes because scalac is a piece of crap -->
         <plugin>
-          <groupId>org.scala-tools</groupId>
-          <artifactId>maven-scala-plugin</artifactId>
-          <version>2.9.1</version>
+          <groupId>net.alchim31.maven</groupId>
+          <artifactId>scala-maven-plugin</artifactId>
+          <version>3.2.1</version>
           <executions>
             <execution>
               <goals>
@@ -172,6 +172,12 @@
       <groupId>io.spray</groupId>
       <artifactId>spray-json_2.10</artifactId>
       <version>1.3.2</version>
+     <exclusions>
+       <exclusion>
+         <groupId>org.scala-lang</groupId>
+         <artifactId>scala-library</artifactId>
+       </exclusion>
+     </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
I noticed today that maven-scala-plugin is no longer maintained and has been replaced by scala-maven-plugin.
