### PR TITLE
Support extracting flow-level configuration properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.etsy.sahale</groupId>
   <artifactId>flowtracker</artifactId>
-  <version>0.6.5-SNAPSHOT</version>
+  <version>0.6.6-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>flowtracker</name>

--- a/src/main/scala/FlowTracker.scala
+++ b/src/main/scala/FlowTracker.scala
@@ -69,7 +69,7 @@ class FlowTracker(val flow: Flow[_], val runCompleted: AtomicBoolean, val hostPo
   val client = getHttpClient
 
   // manages global job state for this run
-  val flowStatus = new FlowStatus(flow)
+  val flowStatus = new FlowStatus(flow, FlowTracker.props)
 
   // so that we can compose a chain of multiple strategies, end users might
   // already have FlowStepStrategy implementations they need to apply later

--- a/src/main/scala/StepStatus.scala
+++ b/src/main/scala/StepStatus.scala
@@ -36,7 +36,7 @@ class StepStatus(val stepNumber: String, val stepId: String, props: Properties) 
   private var stepStartMillis = System.currentTimeMillis
 
   // if users want to track additional JobConf values, put the chosen keys in a CSV
-  // list in flow-tracker.properties entry "user.selected.configs" at build time
+  // list in flow-tracker.properties entry "sahale.step.selected.configs" at build time
   private val propertiesToExtract = Seq("sahale.additional.links") ++ {
     props.getProperty("sahale.step.selected.configs", "").split("""\s*,\s*""").map { _.trim }.filter { _ != "" }.toSeq
   }

--- a/src/main/scala/StepStatus.scala
+++ b/src/main/scala/StepStatus.scala
@@ -38,7 +38,7 @@ class StepStatus(val stepNumber: String, val stepId: String, props: Properties) 
   // if users want to track additional JobConf values, put the chosen keys in a CSV
   // list in flow-tracker.properties entry "user.selected.configs" at build time
   private val propertiesToExtract = Seq("sahale.additional.links") ++ {
-    props.getProperty("user.selected.configs", "").split("""\s*,\s*""").map { _.trim }.filter { _ != "" }.toSeq
+    props.getProperty("sahale.step.selected.configs", "").split("""\s*,\s*""").map { _.trim }.filter { _ != "" }.toSeq
   }
 
   var sources = FlowTracker.UNKNOWN

--- a/src/test/scala/FlowStatusSpec.scala
+++ b/src/test/scala/FlowStatusSpec.scala
@@ -1,5 +1,7 @@
 package com.etsy.sahale
 
+import java.util.Properties
+
 import org.junit.runner.RunWith
 
 import org.scalatest._
@@ -31,7 +33,7 @@ class FlowStatusSpec extends FlatSpec with ShouldMatchers {
   }
 
   "A FlowStatus" should "require a valid Flow instance" in {
-    val fs = new FlowStatus(null)
+    val fs = new FlowStatus(null, new Properties())
     intercept[NullPointerException] {
       fs.toMap
     }


### PR DESCRIPTION
This complements the step-level configuration properties that we already could extract.  Some properties would be the same for every step in a flow, so there's no point in extracting them multiple times.
