### PR TITLE
Add toggle to right pane for job links

### DIFF
--- a/public/scripts/flowgraph-client.js
+++ b/public/scripts/flowgraph-client.js
@@ -43,7 +43,7 @@ $(document).ready(function() {
         ToggleUtil.renderCharts(step_map);
 
         // render the running times chart
-        StackedBarUtil.renderRunningTimes(step_map, flow);
+        StackedBarUtil.render(step_map, flow);
 
         // get event handling wired up
         GraphUtil.setEventHandlers(step_map);

--- a/public/scripts/stackedbar-util.js
+++ b/public/scripts/stackedbar-util.js
@@ -1,15 +1,83 @@
 ////////////////////////////// For running time stacked bar ///////////////////
-var StackedBarUtil = (function($) {
-  var sbutil = {};
+var StackedBarUtil = (function($, StateUtil) {
+    var sbutil = {};
+    var toggle = {};
 
-  sbutil.renderRunningTimes = function(step_map, flow) {
+    toggle.title = [
+	'Running Time Per Step',
+	'Job Links'
+    ];
+    toggle.html = [];
+
+    sbutil.render = function(step_map, flow) {
+	toggle.html = [
+	    renderRunningTimes(step_map, flow),
+	    renderJobLinks(flow)
+	];
+	renderAndRegisterEvent();
+    }
+
+    function renderAndRegisterEvent() {
+	var ndx = parseInt(StateUtil.getRightToggleState());
+	var title = $('#right_toggle_title')
+	title.text(toggle.title[ndx]);
+	title.append('<button class="glyphicon glyphicon-arrow-right" style="float:right" id="right_toggle_right"></button>');
+	title.append('<button class="glyphicon glyphicon-arrow-left" style="float:right" id="right_toggle_left"></button>');
+	console.log(StateUtil.getRightToggleState());
+	console.log(JSON.stringify(toggle.html[ndx]));
+	console.log(JSON.stringify(toggle.title[ndx]));
+	$("#timechart").html(toggle.html[ndx]);
+
+	$("#right_toggle_right").on("click", function(evt) {
+	    StateUtil.incrementRightToggleState(toggle.html.length);
+	    renderAndRegisterEvent();
+	});
+
+	$("#right_toggle_left").on("click", function(evt) {
+	    StateUtil.decrementRightToggleState(toggle.html.length);
+	    renderAndRegisterEvent();
+	});
+    }
+
+    function renderJobLinks(flow) {
+	var interpolationData = {
+	    user: flow.user_name,
+	    job_name: flow.flow_name.replace('com.etsy.scalding.jobs.', '').replace(/\./g, '-'),
+	    flow_id: flow.flow_id
+	};
+
+	var flowLinks = flow.flow_links;
+	
+	var html = '<div class="logbox">';
+	html += '<div style="font-size:10px">';
+
+	if (flowLinks !== undefined) {
+	    var links = flowLinks.split(';');
+	    for (i = 0; i < links.length; ++i) {
+	    	var link = links[i];
+	    	var tokens = link.split('|');
+	    	if (tokens.length == 2) {
+	    	    var name = tokens[0].replace(/\+/g, ' ');
+		    var url = Kiwi.compose(tokens[1], interpolationData);
+		    html += '<div class=steplink><a href=//' + url + ' target=_blank>' + name + '</a></div>';
+	    	}
+	    }
+	}
+
+	html += '</div>';
+	html += "</div>";
+
+	return html;
+    }
+    
+  function renderRunningTimes(step_map, flow) {
     var width_map = generateWidthMap(step_map);
 
     var html = '<div class="inner-stack-box">';
     html += buildStackChart(width_map, step_map);
     html += "</div>";
 
-    $("#timechart").html(html);
+      return html;
   };
 
   function buildStackChart(width_map, step_map) {
@@ -93,4 +161,4 @@ var StackedBarUtil = (function($) {
   }
 
   return sbutil;
-}(jQuery));
+}(jQuery, StateUtil));

--- a/public/scripts/state-util.js
+++ b/public/scripts/state-util.js
@@ -7,7 +7,8 @@ var StateUtil = (function() {
     scale: 1,
     curid: 0,
     tabs_state: {},
-    chart_state: 0
+      chart_state: 0,
+      right_toggle_state: 0
   };
   var sahale_state = null;
 
@@ -80,6 +81,28 @@ var StateUtil = (function() {
   state.getChartState = function() {
     return sahale_state.chart_state;
   }
+
+    state.incrementRightToggleState = function(max) {
+	sahale_state.right_toggle_state += 1;
+	if (sahale_state.right_toggle_state == max) {
+	    sahale_state.right_toggle_state = 0;
+	}
+    }
+
+    state.decrementRightToggleState = function(max) {
+	if (sahale_state.right_toggle_state == 0) {
+	    sahale_state.right_toggle_state = max - 1;
+	} else {
+	    sahale_state.right_toggle_state -= 1;
+	}
+    }
+
+    state.getRightToggleState = function() {
+	if (sahale_state.right_toggle_state === null) {
+	    sahale_state.right_toggle_state = 0;
+	}
+	return sahale_state.right_toggle_state;
+    }
 
   // called from graph-util just before setFlowState is called on page refresh
   state.updateViewState = function(transx, transy, sc) {

--- a/views/flowgraph.jade
+++ b/views/flowgraph.jade
@@ -13,7 +13,7 @@ block content
             div.panel.panel-default
               div.panel-heading#actitle Mapper & Reducer Counts Per Step
                 span(id="actoggle_right",style="float:right",class="glyphicon glyphicon-arrow-right")
-                span(id="actoggle_left",style="float:right",class="glyphicon glyphicon-arrow-left")		
+                span(id="actoggle_left",style="float:right",class="glyphicon glyphicon-arrow-left")
               div.panel-body
                 div.subpanel#areachart(overflow-x='auto')
           div.col-md-6.col-centered

--- a/views/flowgraph.jade
+++ b/views/flowgraph.jade
@@ -18,7 +18,9 @@ block content
                 div.subpanel#areachart(overflow-x='auto')
           div.col-md-6.col-centered
             div.panel.panel-default
-              div.panel-heading Running Time Per Step
+              div.panel-heading#right_toggle_title Running Time Per Step
+                span(id="right_toggle_right",style="float:right",class="glyphicon glyphicon-arrow-right")
+                span(id="right_toggle_left",style="float:right",class="glyphicon glyphicon-arrow-left")
               div.panel-body
                 div.subpanel#timechart
     div.row.row-centered


### PR DESCRIPTION
This adds a toggle to the right pane on the individual flow view (where the running times per step graph is now) similar to that in the left pane.  Right now the only other view a list of flow-level links to complement the step-level links we are already exposing.
