### PR TITLE
Show happy elephant if the job is successfull

### DIFF
--- a/public/scripts/graph-util.js
+++ b/public/scripts/graph-util.js
@@ -82,7 +82,7 @@ var GraphUtil = (function($, d3, dagreD3, ViewUtil, ChartUtil, StateUtil) {
     }
 
     function getImageByStepStatus(item) {
-	switch(item.stepstatus) {
+	switch(item.step_status) {
 	case "RUNNING": case "SUMBITTED": case "SUCCESSFUL":
             return "/images/happy_elephant.png";
 	case "FAILED":


### PR DESCRIPTION
There was a typo in a field access. That was the reason why we always showed a skeptical elephant