### PR TITLE
Propogate errors

### DIFF
--- a/public/scripts/sql-util.js
+++ b/public/scripts/sql-util.js
@@ -39,7 +39,7 @@ exports.getSahaleConfigData = function(call_back) {
   for (i in removeFromDsn) {
     sahaleConfigData[removeFromDsn[i]] = '';
   }
-  call_back(sahaleConfigData);
+  call_back(null, sahaleConfigData);
 }
 
 exports.getRunningFlows = function(call_back) {
@@ -153,7 +153,7 @@ function inspect(str, obj) {
 }
 
 ///////////// REST API to update db via POST requests from running Cascading jobs //////////////
-var emptyCallback = function(x) { };
+var emptyCallback = function(error, x) { };
 
 exports.upsertFlow = function(flow_id, data) {
   var epoch_now = getNowEpoch();
@@ -238,14 +238,14 @@ function executeQuery(query, param_array, call_back) {
     conn.query(query, param_array, function(err, rows) {
       if (err) {
         console.log("Error during query in sql-utils. Stack trace: " + err.stack);
-        // Ignore from here, we don't want the server to crash, just let this get messy and move on!
+        call_back(err, null);
       }
       //console.log(rows); // DEBUG
-      call_back(rows);
+      call_back(null, rows);
     });
   } catch(err) {
     console.log("Connection error in sql-utils. Stack trace: " + err.stack);
-    // Ignore from here, we don't want the server to crash, just let this get messy and move on!
+    call_back(err, null);
   } finally {
     if (conn) { conn.end(); }
   }

--- a/routes/index.js
+++ b/routes/index.js
@@ -28,16 +28,24 @@ exports.search = function(req, res) {
 }
 
 /////////// API ENDPOINTS RETURNING JSON DATA /////////
+
+json_callback = function(req, res) {
+  return function(error, data) {
+    if (error == null) {
+      res.json(data);
+    } else {
+      console.log(error.stack)
+      res.status(500).send("Internal error:" + error.message)
+    }
+  }
+}
+
 exports.sahale_config_data = function(req, res) {
-    sqlutil.getSahaleConfigData(
-      function(data) { res.json(data); }
-    );
+    sqlutil.getSahaleConfigData(json_callback(req, res));
 }
 
 exports.flows_running = function(req, res) {
-  sqlutil.getRunningFlows(
-    function(data) { res.json(data); }
-  );
+  sqlutil.getRunningFlows(json_callback(req, res));
 };
 
 /**
@@ -45,9 +53,7 @@ exports.flows_running = function(req, res) {
  * Use flows_completed_all_ids and the individual flow API.
  */
 exports.flows_completed = function(req, res) {
-  sqlutil.getCompletedFlows(
-    function(data) { res.json(data); }
-  );
+  sqlutil.getCompletedFlows(json_callback(req, res));
 };
 
 exports.flows_completed_all_ids = function(req, res) {
@@ -57,64 +63,62 @@ exports.flows_completed_all_ids = function(req, res) {
 }
 
 exports.flows_completed_all = function(req, res) {
-  sqlutil.getAllCompletedFlows(
-    function(data) { res.json(data); }
-  );
+  sqlutil.getAllCompletedFlows(json_callback(req, res));
 };
 
 exports.flow_search = function(req, res){
   sqlutil.getMatchingFlows(
     req.param('searchterm'),
-    function(data) { res.json(data); }
+    json_callback(req, res)
   );
 };
 
 exports.steps = function(req, res){
   sqlutil.getStepsByFlowId(
     req.param('flow_id'),
-    function(data) { res.json(data); }
+    json_callback(req, res)
   );
 };
 
 exports.flow = function(req, res){
   sqlutil.getFlowByFlowId(
     req.param('flow_id'),
-    function(data) { res.json(data); }
+    json_callback(req, res)
   );
 };
 
 exports.edges = function(req, res) {
   sqlutil.getEdgesByFlowId(
     req.param('flow_id'),
-    function(data) { res.json(data); }
+    json_callback(req, res)
   );
 };
 
 exports.flow_history = function(req, res) {
   sqlutil.getFlowsByJobName(
     req.param('flow_name'),
-    function(data) { res.json(data); }
+    json_callback(req, res)
   );
 }
 
 exports.step_group = function(req, res) {
   sqlutil.getStepsByManyFlowIds(
     req.body.flows,
-    function(data) { res.json(data); }
+    json_callback(req, res)
   );
 }
 
 exports.agg_by_flow = function(req, res) {
   sqlutil.getAggByFlowId(
       req.param('flow_id'),
-      function(data) { res.json(data); }
+      json_callback(req, res)
   );
 }
 
 exports.agg_by_epoch_start_end = function(req, res) {
   sqlutil.getAggByEpochMsStartEnd(
       req.param('flow_id'),
-      function(data) { res.json(data); }
+      json_callback(req, res)
   );
 }
 


### PR DESCRIPTION
Propagate errors in a back-end up to the client.
It is useful for further implementing health checks and for the monitoring.