### PR TITLE
Push step descriptions to Sahale

### DIFF
--- a/public/scripts/graph-util.js
+++ b/public/scripts/graph-util.js
@@ -73,7 +73,7 @@ var GraphUtil = (function($, d3, dagreD3, ViewUtil, ChartUtil, StateUtil) {
 
     function addElephant(item) {
 	return '<img width="40px" height="40px" ' +
-	    'title="MapReduce Job (Step ' + item.step_number + ' of Flow)" ' +
+	    'title="MapReduce Job (Step ' + item.step_number + ' of Flow)\n' + getStepDescription(item) +  '" ' +
 	    'style="width:40px;height:40px;background-color:' +
 	    ViewUtil.getColorByStepStatus(item) + '" ' +
 	    'src="' + getImageByStepStatus(item) + '" ' +
@@ -90,6 +90,10 @@ var GraphUtil = (function($, d3, dagreD3, ViewUtil, ChartUtil, StateUtil) {
 	default:
             return "/images/skeptical_elephant.png";
 	}
+    }
+
+    function getStepDescription(step) {
+	return step.config_props["scalding.step.descriptions"] || ""
     }
 
     function renderViewLayout(graph_data) {

--- a/src/main/scala/StepStatus.scala
+++ b/src/main/scala/StepStatus.scala
@@ -144,7 +144,7 @@ class StepStatus(val flow: Flow[_], val stepNumber: Int, val stepId: String, pro
 
   // if users want to track additional JobConf values, put the chosen keys in a CSV
   // list in flow-tracker.properties entry "sahale.step.selected.configs" at build time
-  private val propertiesToExtract = Seq("sahale.additional.links") ++ {
+  private val propertiesToExtract = Seq("sahale.additional.links", "scalding.step.descriptions") ++ {
     props.getProperty("sahale.step.selected.configs", "")
       .split(""",""").map { _.trim }.filter { _ != "" }.toSeq
   }


### PR DESCRIPTION
Scalding support adding a text description to a TypedPipe. For each step this descriptions are concatenated and added "scalding.step.descriptions" configuration variable.

When a user does not explicitly adds a description using .withDescription the scalding framework add a filename and a line number which is also quite useful.

This pull requests adds this description to UI so it is much easier to understand what each step is doing

For more info look https://github.com/twitter/scalding/pull/1283/files