### PR TITLE
delete kryo and cascading deps not necessary for compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,18 +210,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.esotericsoftware.kryo</groupId>
-      <artifactId>kryo</artifactId>
-      <version>2.21</version>
-    </dependency>
-
-    <dependency>
-      <groupId>cascading.kryo</groupId>
-      <artifactId>cascading.kryo</artifactId>
-      <version>0.4.7</version>
-    </dependency>
-
-    <dependency>
       <groupId>io.spray</groupId>
       <artifactId>spray-json_2.11</artifactId>
       <version>1.3.2</version>
@@ -242,18 +230,6 @@
     <dependency>
       <groupId>cascading</groupId>
       <artifactId>cascading-core</artifactId>
-      <version>${cascading.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>cascading</groupId>
-      <artifactId>cascading-platform</artifactId>
-      <version>${cascading.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>cascading</groupId>
-      <artifactId>cascading-hadoop</artifactId>
       <version>${cascading.version}</version>
     </dependency>
 


### PR DESCRIPTION
This does not get us closer to publishing, but it's something i noticed last week while working on the SBT build.  Sahale imports some things that it does not actually need for compilation, and then those things add to the dependency mess downstream...

To test, I deleted these and confirmed that the library still compiles and tests still pass.