### PR TITLE
Link reformatting

### DIFF
--- a/public/scripts/data-util.js
+++ b/public/scripts/data-util.js
@@ -154,8 +154,8 @@ var DataUtil = (function() {
         return str;
     }
 
-    data.doRegexReplacement = function (jt_url, regexes) {
-        var name = null;
+    data.doRegexReplacement = function (jt_url, regexes, default_value) {
+        var name = default_value;
 
         if(!regexes) {
             return name;
@@ -178,8 +178,7 @@ var DataUtil = (function() {
     function getClusterNameMapping(out_flow) {
 	var cnm = server_config['cluster_name_mapping'] || {};
 	var name = cnm[out_flow.jt_url] ||
-        data.doRegexReplacement(out_flow.jt_url, server_config['cluster_name_regexes']) ||
-        'Unknown';
+        data.doRegexReplacement(out_flow.jt_url, server_config['cluster_name_regexes'], 'Unknown');
 
     return name;
     }

--- a/public/scripts/data-util.js
+++ b/public/scripts/data-util.js
@@ -154,7 +154,7 @@ var DataUtil = (function() {
         return str;
     }
 
-    function doRegexReplacement(jt_url, regexes) {
+    data.doRegexReplacement = function (jt_url, regexes) {
         var name = null;
 
         if(!regexes) {
@@ -178,7 +178,7 @@ var DataUtil = (function() {
     function getClusterNameMapping(out_flow) {
 	var cnm = server_config['cluster_name_mapping'] || {};
 	var name = cnm[out_flow.jt_url] ||
-        doRegexReplacement(out_flow.jt_url, server_config['cluster_name_regexes']) ||
+        data.doRegexReplacement(out_flow.jt_url, server_config['cluster_name_regexes']) ||
         'Unknown';
 
     return name;

--- a/public/scripts/data-util.js
+++ b/public/scripts/data-util.js
@@ -106,6 +106,36 @@ var DataUtil = (function() {
 	return step;
     }
 
+    data.doRegexReplacement = function (jt_url, regexes, default_value) {
+        // A utility function for rewriting cluster host names according to the
+        // config options cluster_name_regexes and cluster_link_regexes.
+        // The `regexes` arg is a mapping from regex => replacement string;
+        // if you put capture groups in the regex, then you can reference them
+        // in the capture group using javascript standard notation, e.g.
+        // the regex-to-replacement mapping
+        //    "cluster-([0-9]+)-master": "cluster-number-$1"
+        // will remap the cluster "cluster-123-master" to "cluster-number-123"
+        var name = default_value;
+
+        if(!regexes) {
+            return name;
+        }
+
+        Object.keys(regexes).forEach(function(regex) {
+            var pattern = new RegExp(regex);
+            var matches = pattern.exec(jt_url);
+            if (matches) {
+                // We should probably really return upon first hit, but we will
+                // leave this as it originally was to avoid altering existing
+                // behavior
+                name = insertCaptureGroups(regexes[regex], matches);
+            }
+        });
+
+        return name;
+    }
+
+
     function checkedStepUnpack(step, group, counter, defaultValue) {
 	if (!step || !group || !counter) {
 	    console.log("Invalid value found in step['counters'][group][counter]");
@@ -152,27 +182,6 @@ var DataUtil = (function() {
         }
 
         return str;
-    }
-
-    data.doRegexReplacement = function (jt_url, regexes, default_value) {
-        var name = default_value;
-
-        if(!regexes) {
-            return name;
-        }
-
-        Object.keys(regexes).forEach(function(regex) {
-            var pattern = new RegExp(regex);
-            var matches = pattern.exec(jt_url);
-            if (matches) {
-                // We should probably really return upon first hit, but we will
-                // leave this as it originally was to avoid altering existing
-                // behavior
-                name = insertCaptureGroups(regexes[regex], matches);
-            }
-        });
-
-        return name;
     }
 
     function getClusterNameMapping(out_flow) {

--- a/public/scripts/view-util.js
+++ b/public/scripts/view-util.js
@@ -304,12 +304,12 @@ var ViewUtil = (function($, DataUtil) {
 
         var config = DataUtil.getConfigState();
 
-        var hostRegexes = config['cluster_link_regexes'] || defaultHostRegexes;
-        var template = config['custom_link_template'] || defaultLinkTemplate;
+        var hostRegexes = config['cluster_link_host_regexes'] || defaultHostRegexes;
+        var template = config['cluster_link_template'] || defaultLinkTemplate;
 
         return Kiwi.compose(template, {
                 defaultScheme: defaultScheme,
-                host: DataUtil.doRegexReplacement(rawHost, hostRegexes),
+                host: DataUtil.doRegexReplacement(rawHost, hostRegexes, rawHost),
                 port: port,
                 path: path
             });

--- a/public/scripts/view-util.js
+++ b/public/scripts/view-util.js
@@ -423,12 +423,12 @@ var ViewUtil = (function($) {
                 if (step.failed_map_tasks > 0) {
                     var failedMapTasks = jobLink.replace("/job/", "/attempts/") + "/m/FAILED"
                     logLinks.push({name: 'Failed Map Tasks', url: failedMapTasks});
-                    insertGlobalFailLink('Map', failedMapTasks);
+                    insertGlobalFailLink('Map', failedMapTasks, step);
                 }
                 if (step.failed_reduce_tasks > 0) {
                     var failedReduceTasks = jobLink.replace("/job/", "/attempts/") + "/r/FAILED"
                     logLinks.push({name: 'Failed Reduce Tasks', url: failedReduceTasks});
-                    insertGlobalFailLink('Reduce', failedReduceTasks);
+                    insertGlobalFailLink('Reduce', failedReduceTasks, step);
                 }
             }
             logLinks.push({name: 'ApplicationMaster', url: buildHref('//', jt_host, '8088', '/cluster/app/' + step.job_id.replace('job_', 'application_'))});

--- a/public/scripts/view-util.js
+++ b/public/scripts/view-util.js
@@ -1,5 +1,5 @@
 // Table-style views are generated with these helpers
-var ViewUtil = (function($) {
+var ViewUtil = (function($, DataUtil) {
     var view = {};
 
     ////////// public ViewUtil functions ////////////////
@@ -298,14 +298,23 @@ var ViewUtil = (function($) {
         return { host: split[0], port: (split.length < 2) ? null : split[1] };
     }
 
-    function buildHref(defaultScheme, host, port, path) {
-        var format = '%{defaultScheme}%{host}:%{port}%{path}'
-        return Kiwi.compose(format, {
-            defaultScheme: defaultScheme,
-            host: host,
-            port: port,
-            path: path
-        });
+    function buildHref(defaultScheme, raw_host, port, path) {
+        var defaultLinkTemplate = '%{defaultScheme}%{host}:%{port}%{path}';
+        defaultLinkTemplate = 'https://dataproc-logs-dot-etsy-dataeng-hadoop-sandbox.appspot.com/proxy/%{host}/%{port}%{path}';
+
+        var host_regexes = DataUtil.getConfigState()['cluster_link_regexes'] || {};
+
+        host_regexes = { '(.*)-(m|w-[0-9]+)': '$1/$2' };
+        var host = DataUtil.doRegexReplacement(raw_host, host_regexes);
+
+        return Kiwi.compose(
+            DataUtil.getConfigState()['custom_link_template'] || defaultLinkTemplate,
+            {
+                defaultScheme: defaultScheme,
+                host: host,
+                port: port,
+                path: path
+            });
     }
 
     function makeYarnUrl(flow, step) {
@@ -460,4 +469,4 @@ var ViewUtil = (function($) {
 
     return view;
 
-}(jQuery));
+}(jQuery, DataUtil));

--- a/public/scripts/view-util.js
+++ b/public/scripts/view-util.js
@@ -298,20 +298,18 @@ var ViewUtil = (function($, DataUtil) {
         return { host: split[0], port: (split.length < 2) ? null : split[1] };
     }
 
-    function buildHref(defaultScheme, raw_host, port, path) {
+    function buildHref(defaultScheme, rawHost, port, path) {
         var defaultLinkTemplate = '%{defaultScheme}%{host}:%{port}%{path}';
-        defaultLinkTemplate = 'https://dataproc-logs-dot-etsy-dataeng-hadoop-sandbox.appspot.com/proxy/%{host}/%{port}%{path}';
+        var defaultHostRegexes = {}; // by default do not change host name
 
-        var host_regexes = DataUtil.getConfigState()['cluster_link_regexes'] || {};
+        var config = DataUtil.getConfigState();
 
-        host_regexes = { '(.*)-(m|w-[0-9]+)': '$1/$2' };
-        var host = DataUtil.doRegexReplacement(raw_host, host_regexes);
+        var hostRegexes = config['cluster_link_regexes'] || defaultHostRegexes;
+        var template = config['custom_link_template'] || defaultLinkTemplate;
 
-        return Kiwi.compose(
-            DataUtil.getConfigState()['custom_link_template'] || defaultLinkTemplate,
-            {
+        return Kiwi.compose(template, {
                 defaultScheme: defaultScheme,
-                host: host,
+                host: DataUtil.doRegexReplacement(rawHost, hostRegexes),
                 port: port,
                 path: path
             });

--- a/public/scripts/view-util.js
+++ b/public/scripts/view-util.js
@@ -438,13 +438,14 @@ var ViewUtil = (function($, DataUtil) {
             var jobLink = makeYarnUrl(flow, step);
             logLinks.push({name: 'View Hadoop Logs', url: jobLink});
             if (step.step_status == 'FAILED') {
-                // We know this is a History Server link at this point, so this replacement should be valid
                 if (step.failed_map_tasks > 0) {
+                    // We know this is a History Server link at this point, so this replacement should be valid
                     var failedMapTasks = jobLink.replace("/job/", "/attempts/") + "/m/FAILED"
                     logLinks.push({name: 'Failed Map Tasks', url: failedMapTasks});
                     insertGlobalFailLink('Map', failedMapTasks, step);
                 }
                 if (step.failed_reduce_tasks > 0) {
+                    // We know this is a History Server link at this point, so this replacement should be valid
                     var failedReduceTasks = jobLink.replace("/job/", "/attempts/") + "/r/FAILED"
                     logLinks.push({name: 'Failed Reduce Tasks', url: failedReduceTasks});
                     insertGlobalFailLink('Reduce', failedReduceTasks, step);

--- a/public/scripts/view-util.js
+++ b/public/scripts/view-util.js
@@ -298,8 +298,20 @@ var ViewUtil = (function($, DataUtil) {
         return { host: split[0], port: (split.length < 2) ? null : split[1] };
     }
 
-    function buildHref(defaultScheme, rawHost, port, path) {
-        var defaultLinkTemplate = '%{defaultScheme}%{host}:%{port}%{path}';
+    function buildHref(schemeWithSlashes, rawHost, port, path) {
+        // schemeWithSlashes is what it sounds like, e.g.
+        //  `http://` or `https://` (or `//`, ie inherit the current scheme)
+        //
+        // rawHost is the host name that we received from the FlowTracker.
+        // To build the host used in assembling the outgoing links, we make
+        // any pre-configured tranformations (defined in the db-config.json
+        // file as cluster_link_host_regexes).
+        //
+        // port is, uh, the port
+        //
+        // path is the full path, including any querystring or fragment
+        // components.
+        var defaultLinkTemplate = '%{schemeWithSlashes}%{host}:%{port}%{path}';
         var defaultHostRegexes = {}; // by default do not change host name
 
         var config = DataUtil.getConfigState();
@@ -308,7 +320,7 @@ var ViewUtil = (function($, DataUtil) {
         var template = config['cluster_link_template'] || defaultLinkTemplate;
 
         return Kiwi.compose(template, {
-                defaultScheme: defaultScheme,
+                schemeWithSlashes: schemeWithSlashes,
                 host: DataUtil.doRegexReplacement(rawHost, hostRegexes, rawHost),
                 port: port,
                 path: path

--- a/public/scripts/view-util.js
+++ b/public/scripts/view-util.js
@@ -299,7 +299,13 @@ var ViewUtil = (function($) {
     }
 
     function buildHref(defaultScheme, host, port, path) {
-        return defaultScheme + host + port + path;
+        var format = '%{defaultScheme}%{host}:%{port}%{path}'
+        return Kiwi.compose(format, {
+            defaultScheme: defaultScheme,
+            host: host,
+            port: port,
+            path: path
+        });
     }
 
     function makeYarnUrl(flow, step) {


### PR DESCRIPTION
hello again, @nixsticks !!

So this commit adds two optional config settings that affect the UI:

1. `cluster_link_template`, which allows us to configure the builder of the log and application master links arbitrarily, via patterns like `%{host}/abc/123/%{path}`

2. `cluster_link_host_regexes`, which allows us to rewrite the hostname according to the same regex rules that we added in a prior commit (in which we changed `cluster_name_regexes` to support capture groups).

When neither of these is provided, the default behavior matches what Sahale has always done.

The changes required refactoring the code a bit in order to centralize the generation of the links.

Also I made a few small cleanups to make the code more modular.

Sorry about the whitespace changes, I will try to revert to tabs on a subsequent commit before merging this PR