### PR TITLE
retry rules for failed update steps

### DIFF
--- a/flowtracker/src/main/scala/FlowTracker.scala
+++ b/flowtracker/src/main/scala/FlowTracker.scala
@@ -137,8 +137,10 @@ class FlowTracker(val flow: Flow[_],
       registerShutdownHook
     }.recover {
       case t: Throwable =>
-        LOG.warn("Failed to initialize FlowTracker.  This is NOT a fatal error. " +
-          "The job will run as normal, but it will not be tracked by Sahale.", t)
+        LOG.warn("""
+          Failed to initialize FlowTracker.  This is NOT a fatal error.
+          The job will run as normal, but it will not be tracked by Sahale.
+          """.stripMargin.trim, t)
         runCompleted.set(true)
     }
 
@@ -154,17 +156,20 @@ class FlowTracker(val flow: Flow[_],
           }
         }.recover {
           case t: Throwable if 1 + numFailures < maxFailures=>
-            LOG.warn("FlowTracker has thrown an exception because an update iteration failed. " +
-              "This is NOT a fatal error. " +
-              "We will skip this update iteration and then try again. " +
-              s"${maxFailures - numFailures} attempts remain", t)
+            LOG.warn(s"""
+              FlowTracker has thrown an exception because an update iteration
+              failed. This is NOT a fatal error. We will skip this update
+              iteration. ${maxFailures - numFailures} attempts remain.
+              """.stripMargin.trim, t)
 
             numFailures += 1
 
           case t: Throwable =>
-            LOG.warn("FlowTracker for this run has thrown an exception. " +
-              "This is NOT a fatal error. " +
-              "The run will complete as normal, but the remainder will not be tracked by Sahale.", t)
+            LOG.warn("""
+              FlowTracker for this run has thrown an exception. This is NOT a
+              fatal error. The run will complete as normal, but the remainder
+              will not be tracked by Sahale.
+              """.stripMargin.trim, t)
             runCompleted.set(true)
         }
 

--- a/flowtracker/src/main/scala/FlowTracker.scala
+++ b/flowtracker/src/main/scala/FlowTracker.scala
@@ -18,6 +18,7 @@ import java.net.SocketException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.Properties
 
+import scala.util.Try
 import scala.collection.mutable
 import scala.collection.JavaConversions._
 
@@ -131,29 +132,52 @@ class FlowTracker(val flow: Flow[_],
   def this(flow: Flow[_], runCompleted: AtomicBoolean) = this(flow, runCompleted, "", false)
 
   override def run(): Unit = {
-    try {
+    Try {
       initializeTrackedJobState
       registerShutdownHook
+    }.recover {
+      case t: Throwable =>
+        LOG.warn("Failed to initialize FlowTracker.  This is NOT a fatal error. " +
+          "The job will run as normal, but it will not be tracked by Sahale.", t)
+        runCompleted.set(true)
+    }
 
-      while (!runCompleted.get) {
+    val maxFailures = 10
+    var numFailures = 0
+    while(!runCompleted.get) {
+      Try {
+          updateSteps
+          updateFlow
+          updateAggregates
+          if (!disableProgressBar) {
+            logFlowStatus
+          }
+        }.recover {
+          case t: Throwable if 1 + numFailures < maxFailures=>
+            LOG.warn("FlowTracker has thrown an exception because an update iteration failed. " +
+              "This is NOT a fatal error. " +
+              "We will skip this update iteration and then try again. " +
+              s"${maxFailures - numFailures} attempts remain", t)
+
+            numFailures += 1
+
+          case t: Throwable =>
+            LOG.warn("FlowTracker for this run has thrown an exception. " +
+              "This is NOT a fatal error. " +
+              "The run will complete as normal, but the remainder will not be tracked by Sahale.", t)
+            runCompleted.set(true)
+        }
+
+        sleep(REFRESH_INTERVAL_MS)
+    }
+
+    // Push the final updates, but only if we have not hit our failure limit
+    if(numFailures < maxFailures) {
+      Try {
         updateSteps
         updateFlow
         updateAggregates
-        if (!disableProgressBar) {
-          logFlowStatus
-        }
-        sleep(REFRESH_INTERVAL_MS)
       }
-    } catch {
-      case t: Throwable => {
-        LOG.warn("FlowTracker for this run has thrown an exception. " +
-          "The run will complete as normal, but the remainder will not be tracked.", t)
-        runCompleted.set(true);
-      }
-    } finally {
-      updateSteps
-      updateFlow
-      updateAggregates
     }
   }
 


### PR DESCRIPTION
Hi @nixsticks !

This commit adds failure-recovery for a condition that we have observed intermittently for jobs running on Google DataProc, in which the FlowTracker fails to retrieve job statistics and then terminates.  This failure causes Sahale to lose track of running jobs, but does not cause the jobs to fail.

We are hoping that the failure is intermittent, and that the FlowTracker will be able to recover on subsequent iterations, so we have enabled the FlowTracker to retry up to 10 times before terminating.

I have run jobs using this new code and confirmed that they do not break anything, but due to the intermittency of the failure it will take time to see whether it actually fixes the problem.

For reference, below is an example stack trace for this failure:
```
2018-02-01 19:30:23,160 WARN com.etsy.sahale.FlowTracker: FlowTracker for this run has thrown an exception. The run will complete as normal, but the remainder will not be tracked.
cascading.flow.FlowException: unable to get progress
	at cascading.stats.hadoop.BaseHadoopStepStats.getMapProgress(BaseHadoopStepStats.java:376)
	at com.etsy.sahale.StepStatus.getMapProgress(StepStatus.scala:103)
	at com.etsy.sahale.StepStatus.update(StepStatus.scala:63)
	at com.etsy.sahale.FlowTracker$$anonfun$updateSteps$1.apply(FlowTracker.scala:168)
	at com.etsy.sahale.FlowTracker$$anonfun$updateSteps$1.apply(FlowTracker.scala:164)
	at scala.collection.TraversableOnce$$anonfun$foldLeft$1.apply(TraversableOnce.scala:157)
	at scala.collection.TraversableOnce$$anonfun$foldLeft$1.apply(TraversableOnce.scala:157)
	at scala.collection.mutable.HashMap$$anonfun$foreach$1.apply(HashMap.scala:130)
	at scala.collection.mutable.HashMap$$anonfun$foreach$1.apply(HashMap.scala:130)
	at scala.collection.mutable.HashTable$class.foreachEntry(HashTable.scala:236)
	at scala.collection.mutable.HashMap.foreachEntry(HashMap.scala:40)
	at scala.collection.mutable.HashMap.foreach(HashMap.scala:130)
	at scala.collection.TraversableOnce$class.foldLeft(TraversableOnce.scala:157)
	at scala.collection.AbstractTraversable.foldLeft(Traversable.scala:104)
	at com.etsy.sahale.FlowTracker.updateSteps(FlowTracker.scala:164)
	at com.etsy.sahale.FlowTracker.run(FlowTracker.scala:139)
	at java.lang.Thread.run(Thread.java:748)
```