### PR TITLE
Google auth fix

### DIFF
--- a/flowtracker-gcp/pom.xml
+++ b/flowtracker-gcp/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.etsy.sahale</groupId>
     <artifactId>flowtracker-pom_2.11</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
   </parent>
 
   <name>flowtracker-gcp</name>

--- a/flowtracker-gcp/src/main/scala/GoogleAuthFlowTracker.scala
+++ b/flowtracker-gcp/src/main/scala/GoogleAuthFlowTracker.scala
@@ -36,7 +36,10 @@ case class IdToken(audience: String, transport: HttpClient, serviceAccountJsonFi
     // Returns true if the token has not yet been retrieved, or if the token
     // has expired
     _expiresAtSeconds.forall { expSeconds =>
-      expSeconds <= System.currentTimeMillis / 1000
+      // Indicate expiry 1 minute before the token has actually expired,
+      // to prevent us from using a token that will expire by the time it is
+      // processed by the server
+      expSeconds <= 60 + System.currentTimeMillis / 1000
     }
   }
 

--- a/flowtracker-gcp/src/main/scala/GoogleAuthFlowTracker.scala
+++ b/flowtracker-gcp/src/main/scala/GoogleAuthFlowTracker.scala
@@ -179,6 +179,13 @@ object IdToken {
       sys.error("Failed to retrieve google-signed identity token")
     }
   }
+
+  def getAudience(hostPort: String) = {
+    val uri = new URI(hostPort)
+
+    // Do not send the port as part of the audience, only the scheme and host
+    new URI(uri.getScheme, uri.getHost, null, null).toString
+  }
 }
 
 class GoogleAuthFlowTracker(
@@ -210,7 +217,7 @@ class GoogleAuthFlowTracker(
 
   @transient // should not generally happen, but do not allow credentials to be serialized
   private val idToken: IdToken = IdToken(
-    audience = this.serverHostPort.split(":").head, // Do not send the port as part of the audience
+    audience = IdToken.getAudience(this.serverHostPort),
     transport = FlowTracker.getHttpClient,
     serviceAccountJsonFile = Option(serviceAccountJsonFilename))
 

--- a/flowtracker/pom.xml
+++ b/flowtracker/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.etsy.sahale</groupId>
     <artifactId>flowtracker-pom_2.11</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
   </parent>
 
   <name>flowtracker</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.etsy.sahale</groupId>
   <artifactId>flowtracker-pom_2.11</artifactId>
   <packaging>pom</packaging>
-  <version>2.0.1</version>
+  <version>2.0.2-SNAPSHOT</version>
 
   <name>flowtracker-pom</name>
   <description>A Cascading Workflow Visualizer</description>


### PR DESCRIPTION
Hi @dossett @nixsticks 

This diff is a minor fix for an issue in which token-retrieval fails because I parsed the server URI improperly in an earlier commit.  I could have sworn I ran a test job successfully, although it sure doesn't look like that would have been possible.

It also adds logic to refresh the id token 1 minute before it actually expires, to eliminate the risk of sending a token that expires by the time it's processed by the server.