### PR TITLE
Correcting the "cluster" link

### DIFF
--- a/public/scripts/view-util.js
+++ b/public/scripts/view-util.js
@@ -207,7 +207,7 @@ var ViewUtil = (function($, DataUtil) {
     }
 
     function renderClusterFilterLink(clusterName) {
-	return '<a href=?cluster=' + clusterName + '>' + clusterName + '</a>';
+	return '<a href="/?cluster=' + clusterName + '">' + clusterName + '</a>';
     }
 
     function renderTabHeader(idnum) {


### PR DESCRIPTION
The current path `?cluster=foo` will always append to the current URI path, which means that from a flowgraph page it just append that argument, rather than showing the list of jobs filtered to that cluster. By specifying the leading slash `/?cluster=foo`, the URL will be correctly set on all pages.