### PR TITLE
DATAGCP-1531 - Add conn and socket timeout to httpclient

### DIFF
--- a/flowtracker-gcp/pom.xml
+++ b/flowtracker-gcp/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.etsy.sahale</groupId>
     <artifactId>flowtracker-pom_2.11</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
   </parent>
 
   <name>flowtracker-gcp</name>

--- a/flowtracker/pom.xml
+++ b/flowtracker/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.etsy.sahale</groupId>
     <artifactId>flowtracker-pom_2.11</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
   </parent>
 
   <name>flowtracker</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.etsy.sahale</groupId>
   <artifactId>flowtracker-pom_2.11</artifactId>
   <packaging>pom</packaging>
-  <version>2.1.0</version>
+  <version>2.2.0</version>
 
   <name>flowtracker-pom</name>
   <description>A Cascading Workflow Visualizer</description>


### PR DESCRIPTION
This sets the default socket and conn timeouts to 5 minutes each. That decision was made from this SO post (many answers below) and felt somewhat safe for us at Etsy (much safer than the default of infinite).

https://stackoverflow.com/questions/9734384/default-timeout-for-httpcomponent-client

`mvn clean install`

```
Discovery starting.
Discovery completed in 75 milliseconds.
Run starting. Expected test count is: 0
DiscoverySuite:
Run completed in 125 milliseconds.
Total number of tests run: 0
Suites: completed 1, aborted 0
Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
No tests were executed.
[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ flowtracker-gcp_2.11 ---
[INFO] Building jar: /Users/vchiapaikeo/my-development/Sahale/flowtracker-gcp/target/flowtracker-gcp_2.11-2.1.0.jar
[INFO] 
[INFO] >>> scala-maven-plugin:3.2.1:doc-jar (generate-javadoc-jar) > generate-sources @ flowtracker-gcp_2.11 >>>
[INFO] 
[INFO] <<< scala-maven-plugin:3.2.1:doc-jar (generate-javadoc-jar) < generate-sources @ flowtracker-gcp_2.11 <<<
[INFO] 
[INFO] 
[INFO] --- scala-maven-plugin:3.2.1:doc-jar (generate-javadoc-jar) @ flowtracker-gcp_2.11 ---
model contains 7 documentable templates
[INFO] Building jar: /Users/vchiapaikeo/my-development/Sahale/flowtracker-gcp/target/flowtracker-gcp_2.11-2.1.0-javadoc.jar
[INFO] 
[INFO] --- maven-source-plugin:2.4:jar-no-fork (attach-sources) @ flowtracker-gcp_2.11 ---
[INFO] Building jar: /Users/vchiapaikeo/my-development/Sahale/flowtracker-gcp/target/flowtracker-gcp_2.11-2.1.0-sources.jar
[INFO] 
[INFO] --- maven-javadoc-plugin:2.10.3:jar (attach-javadocs) @ flowtracker-gcp_2.11 ---
[INFO] 
[INFO] --- maven-install-plugin:2.4:install (default-install) @ flowtracker-gcp_2.11 ---
[INFO] Installing /Users/vchiapaikeo/my-development/Sahale/flowtracker-gcp/target/flowtracker-gcp_2.11-2.1.0.jar to /Users/vchiapaikeo/.m2/repository/com/etsy/sahale/flowtracker-gcp_2.11/2.1.0/flowtracker-gcp_2.11-2.1.0.jar
[INFO] Installing /Users/vchiapaikeo/my-development/Sahale/flowtracker-gcp/pom.xml to /Users/vchiapaikeo/.m2/repository/com/etsy/sahale/flowtracker-gcp_2.11/2.1.0/flowtracker-gcp_2.11-2.1.0.pom
[INFO] Installing /Users/vchiapaikeo/my-development/Sahale/flowtracker-gcp/target/flowtracker-gcp_2.11-2.1.0-javadoc.jar to /Users/vchiapaikeo/.m2/repository/com/etsy/sahale/flowtracker-gcp_2.11/2.1.0/flowtracker-gcp_2.11-2.1.0-javadoc.jar
[INFO] Installing /Users/vchiapaikeo/my-development/Sahale/flowtracker-gcp/target/flowtracker-gcp_2.11-2.1.0-sources.jar to /Users/vchiapaikeo/.m2/repository/com/etsy/sahale/flowtracker-gcp_2.11/2.1.0/flowtracker-gcp_2.11-2.1.0-sources.jar
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for flowtracker-pom 2.1.0:
[INFO] 
[INFO] flowtracker-pom .................................... SUCCESS [  0.192 s]
[INFO] flowtracker ........................................ SUCCESS [ 16.695 s]
[INFO] flowtracker-gcp .................................... SUCCESS [  8.353 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  25.332 s
[INFO] Finished at: 2020-04-10T13:19:36-04:00
[INFO] ------------------------------------------------------------------------
```

Upgrading major version since this is a method signature change.