### PR TITLE
Re-add support for previous default FlowTracker constructor

### DIFF
--- a/flowtracker-gcp/pom.xml
+++ b/flowtracker-gcp/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.etsy.sahale</groupId>
     <artifactId>flowtracker-pom_2.11</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
   </parent>
 
   <name>flowtracker-gcp</name>

--- a/flowtracker/pom.xml
+++ b/flowtracker/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.etsy.sahale</groupId>
     <artifactId>flowtracker-pom_2.11</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
   </parent>
 
   <name>flowtracker</name>

--- a/flowtracker/src/main/scala/FlowTracker.scala
+++ b/flowtracker/src/main/scala/FlowTracker.scala
@@ -135,8 +135,11 @@ class FlowTracker(val flow: Flow[_],
   def this(flow: Flow[_], runCompleted: AtomicBoolean, hostPort: String, httpConnectionTimeout: Int, httpSocketTimeout: Int) =
     this(flow, runCompleted, hostPort, false, httpConnectionTimeout, httpSocketTimeout)
 
+  def this(flow: Flow[_], runCompleted: AtomicBoolean, hostPort: String, disableProgressBar: Boolean) =
+    this(flow, runCompleted, hostPort, disableProgressBar, FlowTracker.HTTP_CONNECTION_TIMEOUT, FlowTracker.HTTP_SOCKET_TIMEOUT)
+
   def this(flow: Flow[_], runCompleted: AtomicBoolean, hostPort: String) =
-    this(flow, runCompleted, hostPort, FlowTracker.HTTP_CONNECTION_TIMEOUT, FlowTracker.HTTP_SOCKET_TIMEOUT)
+    this(flow, runCompleted, hostPort, false, FlowTracker.HTTP_CONNECTION_TIMEOUT, FlowTracker.HTTP_SOCKET_TIMEOUT)
 
   def this(flow: Flow[_], runCompleted: AtomicBoolean) =
     this(flow, runCompleted, "", false, FlowTracker.HTTP_CONNECTION_TIMEOUT, FlowTracker.HTTP_SOCKET_TIMEOUT)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.etsy.sahale</groupId>
   <artifactId>flowtracker-pom_2.11</artifactId>
   <packaging>pom</packaging>
-  <version>2.2.0</version>
+  <version>2.2.1</version>
 
   <name>flowtracker-pom</name>
   <description>A Cascading Workflow Visualizer</description>


### PR DESCRIPTION
Silly mistake on my part to forget support for the original default constructor. This error propped up when I tried running tests locally using my new version.

```
[error] /home/vchiapaikeo/development/BigData/operators-scalding/src/main/java/cascading/jruby/CascadingRunnable.java:49:  error: no suitable constru
ctor found for FlowTracker(Flow,AtomicBoolean,String,Boolean)                                                                                        
[error]       return new FlowTracker(flow, completionTracker, DEFAULT_HOST_PORT, disableProgressBar);                                                
[error] 
```

Adding support for this method signature:
```
this(flow: Flow[_], runCompleted: AtomicBoolean, hostPort: String, disableProgressBar: Boolean)
```

Also, fixing a bug with this constructor:
```
def this(flow: Flow[_], runCompleted: AtomicBoolean, hostPort: String)
```

::shakes head at himself::